### PR TITLE
Refactor/get time diff

### DIFF
--- a/src/module/service-base.ts
+++ b/src/module/service-base.ts
@@ -20,14 +20,20 @@ export class OnvifServiceBase {
         this.timeDiff = 0;
     }
 
-    protected createRequestSoap(body: string) {
-        return createRequestSoap({
-            body,
-            xmlns: this.namespaceAttrList,
-            diff: this.timeDiff,
-            user: this.user,
-            pass: this.pass,
-        });
+    protected createRequestSoap(body: string, withoutUser = false) {
+        return withoutUser
+          ? createRequestSoap({
+              body,
+              xmlns: this.namespaceAttrList,
+              diff: this.timeDiff,
+          })
+          : createRequestSoap({
+              body,
+              xmlns: this.namespaceAttrList,
+              diff: this.timeDiff,
+              user: this.user,
+              pass: this.pass,
+          });
     }
 
     setAuth(user: string, pass: string) {

--- a/src/module/service-device.ts
+++ b/src/module/service-device.ts
@@ -14,6 +14,14 @@ export class OnvifServiceDevice extends OnvifServiceBase{
         return this.timeDiff;
     }
 
+    private fixTimeDiff(date: Date) {
+      if (date) {
+        const deviceTime = date.getTime();
+        const myTime = (new Date()).getTime();
+        this.timeDiff = deviceTime - myTime;
+      }
+    }
+
     getCapabilities(): Promise<Result> {
         let soapBody = '';
         soapBody += '<tds:GetCapabilities>';
@@ -186,16 +194,25 @@ export class OnvifServiceDevice extends OnvifServiceBase{
 
     getSystemDateAndTime(): Promise<Result> {
         const soapBody = '<tds:GetSystemDateAndTime/>';
-        const soap = this.createRequestSoap(soapBody);
-        return requestCommand(this.oxaddr, 'GetSystemDateAndTime', soap).then((result) => {
+        return new Promise<Result>((resolve, reject) => {
+          const soap = this.createRequestSoap(soapBody, true);
+          requestCommand(this.oxaddr, 'GetSystemDateAndTime', soap)
+          .then((result) => {
             const parsed = parseGetSystemDateAndTime(result.converted);
-            if (parsed && parsed.date) {
-                const deviceTime = parsed.date.getTime();
-                const myTime = (new Date()).getTime();
-                this.timeDiff = deviceTime - myTime;
-            }
-            return result;
-        });
+            this.fixTimeDiff(parsed?.date);
+            return resolve(result);
+          })
+          .catch((error) => {
+            const newSoap = this.createRequestSoap(soapBody);
+            requestCommand(this.oxaddr, 'GetSystemDateAndTime', newSoap)
+            .then((result) => {
+              const parsed = parseGetSystemDateAndTime(result.converted);
+              this.fixTimeDiff(parsed?.date);
+              return resolve(result);
+            })
+            .catch((err) => reject(err));
+          });
+        })
     }
 
     setSystemDateAndTime(params: SetSystemDateAndTimeParams): Promise<Result> {


### PR DESCRIPTION
This PR adds a "new" way to obtain the time difference between client and device.
What happens is that when those two have different datetime settings the SOAP request may fail due to incorrect authentication.
Here the `getSystemDateAndTime` is modified so that it first tries an unauthenticated SOAP request (which is ONVIF conformant for this function), if this request fails then it tries again but now with authentication.